### PR TITLE
Fix of Aria rules

### DIFF
--- a/src/components/Dropdown.astro
+++ b/src/components/Dropdown.astro
@@ -6,4 +6,4 @@ const { class: className } = Astro.props;
 ---
 
 
-<div class:list={["astronav-dropdown", className]} aria-expanded="false"><slot/></div>
+<menu class:list={["astronav-dropdown", className]} aria-expanded="false"><slot/></menu>


### PR DESCRIPTION
Aria-expanded should not be assigned to div element. This affects the lighthouse score.