### PR TITLE
Update MenuIcon.astro

### DIFF
--- a/src/components/MenuIcon.astro
+++ b/src/components/MenuIcon.astro
@@ -12,7 +12,7 @@ const { class: className } = Astro.props;
       class:list={[className]}
       width="24"
       height="24"
-      viewBox="0 0 20 20"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg">
       <title>Toggle Menu</title>
       <path


### PR DESCRIPTION
Hi! 

The icon position was bugging me. It seemed it was unaligned somehow. Lower than what was expected.
![image](https://github.com/surjithctly/astro-navbar/assets/170220/4d289a3a-154b-4194-9081-8656242670aa)

Changing the viewbox to match the element's dimensions settled it. Now that the viewbox matches its height, it feels better aligned.
![image](https://github.com/surjithctly/astro-navbar/assets/170220/a0d1c2ff-9e41-4d6f-b785-f4813409f357)

This is a minor cosmetic thing. Hope it's ok.
-cheers
