### PR TITLE
fix: included extra props to enable scoped CSS styles 

### DIFF
--- a/src/components/CloseIcon.astro
+++ b/src/components/CloseIcon.astro
@@ -2,9 +2,9 @@
 interface Props {
   class?: string;
 }
-const { class: className } = Astro.props;
+const { class: className, ...rest } = Astro.props;
 ---
 
-<span class:list={["astronav-close-icon astronav-toggle hidden", className]}
-  ><slot /></span
->
+<span class:list={["astronav-close-icon astronav-toggle hidden", className]} {...rest}>
+  <slot />
+</span>

--- a/src/components/Dropdown.astro
+++ b/src/components/Dropdown.astro
@@ -2,8 +2,8 @@
 interface Props {
     class?: string;
 }
-const { class: className } = Astro.props;
+const { class: className, ...rest } = Astro.props;
 ---
 
 
-<menu class:list={["astronav-dropdown", className]} aria-expanded="false"><slot/></menu>
+<menu class:list={["astronav-dropdown", className]} {...rest} aria-expanded="false"><slot/></menu>

--- a/src/components/DropdownItems.astro
+++ b/src/components/DropdownItems.astro
@@ -2,11 +2,11 @@
 interface Props {
     class?: string;
 }
-const { class: className } = Astro.props;
+const { class: className, ...rest } = Astro.props;
 ---
 
 <div
-    class:list={["astronav-dropdown dropdown-toggle hidden", className]}
+    class:list={["astronav-dropdown dropdown-toggle hidden", className]} {...rest}
     aria-expanded="false">
     <slot />
 </div>

--- a/src/components/DropdownSubmenu.astro
+++ b/src/components/DropdownSubmenu.astro
@@ -2,11 +2,11 @@
 interface Props {
     class?: string;
 }
-const { class: className } = Astro.props;
+const { class: className, ...rest } = Astro.props;
 ---
 
 <div
-    class:list={["astronav-dropdown-submenu", className]}
+    class:list={["astronav-dropdown-submenu", className]} {...rest}
     aria-expanded="false">
     <slot />
 </div>

--- a/src/components/MenuIcon.astro
+++ b/src/components/MenuIcon.astro
@@ -2,7 +2,7 @@
 interface Props {
   class?: string;
 }
-const { class: className } = Astro.props;
+const { class: className, ...rest } = Astro.props;
 ---
 
 <button id="astronav-menu" aria-label="Toggle Menu">
@@ -13,7 +13,8 @@ const { class: className } = Astro.props;
       width="24"
       height="24"
       viewBox="0 0 24 24"
-      xmlns="https://www.w3.org/2000/svg">
+      xmlns="https://www.w3.org/2000/svg"
+      {...rest}>
       <title>Toggle Menu</title>
       <path
         class="astronav-close-icon astronav-toggle hidden"

--- a/src/components/MenuItems.astro
+++ b/src/components/MenuItems.astro
@@ -2,9 +2,9 @@
 interface Props {
     class?: string;
 }
-const { class: className } = Astro.props;
+const { class: className, ...rest } = Astro.props;
 ---
 
-<nav class:list={["astronav-items astronav-toggle", className]}>
+<nav class:list={["astronav-items astronav-toggle", className]} {...rest}>
     <slot />
 </nav>

--- a/src/components/OpenIcon.astro
+++ b/src/components/OpenIcon.astro
@@ -2,9 +2,9 @@
 interface Props {
   class?: string;
 }
-const { class: className } = Astro.props;
+const { class: className, ...rest } = Astro.props;
 ---
 
-<span class:list={["astronav-open-icon astronav-toggle", className]}
+<span class:list={["astronav-open-icon astronav-toggle", className]} {...rest}
   ><slot /></span
 >

--- a/src/components/StickyHeader.astro
+++ b/src/components/StickyHeader.astro
@@ -10,10 +10,11 @@ const {
   defaultClass = "",
   activeClass = "",
   class: className = "",
+  ...rest
 } = Astro.props;
 ---
 
-<header class:list={["astronav-sticky-header", className, defaultClass]}>
+<header class:list={["astronav-sticky-header", className, defaultClass]} {...rest}>
   <slot />
 </header>
 


### PR DESCRIPTION
Using Scoped Styles when including the component would not add the compiled class name when using scoped css. 

Based on the Astro docs passing the `...rest` of the props will amke sure it passest the `data-astro-cid-*` attribute.

[Passing a class to a child component](https://docs.astro.build/en/guides/styling/#passing-a-class-to-a-child-component)

