### PR TITLE
Add more element types that are considered 'inside the dropdown'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-navbar",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Responsive Mobile Navigation with Dropdown in Astro",
   "type": "module",
   "exports": "./index.ts",

--- a/src/Astronav.astro
+++ b/src/Astronav.astro
@@ -103,7 +103,9 @@ function closeAllDropdowns(event) {
   );
   const isButtonInsideDropdown = [
     ...document.querySelectorAll(
-      ".astronav-dropdown button, .astronav-dropdown-submenu button, #astronav-menu"
+      `.astronav-dropdown button, .astronav-dropdown label, .astronav-dropdown input,
+	  .astronav-dropdown-submenu button, .astronav-dropdown-submenu label, .astronav-dropdown-submenu input,
+	  #astronav-menu`
     ),
   ].some((button) => button.contains(event.target));
   if (!isButtonInsideDropdown) {


### PR DESCRIPTION
I was using a dropdown in order to create an options menu. However, any element that isn't a button is considered to not be inside the dropdown, causing the dropdown to close. In order to fix this, I have updated the selector to also consider inputs and labels to be inside the dropdown and prevent it from closing. This could possibly be updated in the future to include more elements that are commonly used for inputs.