### PR TITLE
Use http in svg xmlns url instead of https in MenuIcon.astro

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-navbar",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "description": "Responsive Mobile Navigation with Dropdown in Astro",
   "type": "module",
   "exports": "./index.ts",

--- a/src/components/MenuIcon.astro
+++ b/src/components/MenuIcon.astro
@@ -13,7 +13,7 @@ const { class: className, ...rest } = Astro.props;
       width="24"
       height="24"
       viewBox="0 0 24 24"
-      xmlns="https://www.w3.org/2000/svg"
+      xmlns="http://www.w3.org/2000/svg"
       {...rest}>
       <title>Toggle Menu</title>
       <path


### PR DESCRIPTION
Hi @surjithctly,

It looks like on line 16 in `MenuIcon.astro`, `https` should not be used here and `http` should be used instead :

https://github.com/surjithctly/astro-navbar/blob/c3e852b2aceaa753e970f414ac6a8daa5846e274/src/components/MenuIcon.astro#L10-L17

As recommended in:

- https://rocketvalidator.com/html-validation/bad-value-https-www-w3-org-2000-svg-for-the-attribute-xmlns-only-http-www-w3-org-2000-svg-permitted-here
- https://developer.mozilla.org/en-US/docs/Web/SVG/Namespaces_Crash_Course


> The only permitted value for the xmlns attribute is `http://www.w3.org/2000/svg`.

>Although using https in the URL looks like it’s going to be more secure, in fact this URL is not used to connect it to, only to declare the namespace.
