### PR TITLE
fix: nable multiple navbars on a page

### DIFF
--- a/src/Astronav.astro
+++ b/src/Astronav.astro
@@ -1,184 +1,194 @@
 ---
 ---
-<slot/>
+<nav class="astronav-toggle-root">
+  <slot />
+</nav>
 
 <script>
-["DOMContentLoaded", "astro:after-swap"].forEach((event) => {
-  document.addEventListener(event, addListeners);
-});
+  ["DOMContentLoaded", "astro:after-swap"].forEach((event) => {
+    document.addEventListener(event, addListeners);
+  });
 
-// Function to clone and replace elements
-function cloneAndReplace(element) {
-  const clone = element.cloneNode(true);
-  element.parentNode.replaceChild(clone, element);
-}
-
-function addListeners() {
-  document.querySelectorAll('button[data-astronav]').forEach((button) => {
-    addListenersForButton(`button[data-astronav="${button.getAttribute('data-astronav')}"]`)
-  })
-}
-
-function addListenersForButton(selector: string) {
-  // Clean up existing listeners
-  const oldMenuButton = document.querySelector(selector);
-
-  if (oldMenuButton) {
-    cloneAndReplace(oldMenuButton);
+  // Function to clone and replace elements
+  function cloneAndReplace(element) {
+    const clone = element.cloneNode(true);
+    element.parentNode.replaceChild(clone, element);
   }
 
-  const oldDropdownMenus = document.querySelectorAll(".astronav-dropdown");
+  function addListeners() {
+    // Iterate over each Astronav instance
+    document.querySelectorAll(".astronav-toggle-root").forEach((root) => {
+      addListenersToRoot(root);
+    });
+  }
 
-  oldDropdownMenus.forEach((menu) => {
-    cloneAndReplace(menu);
-  });
+  function addListenersToRoot(root) {
+    // Clean up existing listeners by cloning interactive elements
+    const oldMenuButton = root.querySelector("button[data-astronav]");
+    if (oldMenuButton) {
+      cloneAndReplace(oldMenuButton);
+    }
 
-  // Mobile nav toggle
-  const menuButton = document.querySelector(selector);
-  menuButton && menuButton.addEventListener("click", toggleMobileNav);
+    const oldDropdownMenus = root.querySelectorAll(".astronav-dropdown");
+    oldDropdownMenus.forEach((menu) => {
+      cloneAndReplace(menu);
+    });
 
-  // Dropdown menus
-  const dropdownMenus = document.querySelectorAll(".astronav-dropdown");
-  
-  dropdownMenus.forEach((menu) => {
-    const button = menu.querySelector("button");
+    // Re-query elements after cloning
+    const menuButton = root.querySelector("button[data-astronav]");
+    const dropdownMenus = root.querySelectorAll(".astronav-dropdown");
 
-    button && 
-      button.addEventListener("click", (event) =>
-        toggleDropdownMenu(event, menu, dropdownMenus)
+    // Mobile nav toggle
+    if (menuButton) {
+      menuButton.addEventListener("click", (event) => {
+        event.stopPropagation();
+        toggleMobileNav(root);
+      });
+
+      // Close menu on click (if enabled)
+      const closeOnClick = menuButton.getAttribute("data-closeOnClick");
+      if (closeOnClick) {
+        handleCloseOnClick(root);
+      }
+    }
+
+    // Dropdown menus
+    dropdownMenus.forEach((menu) => {
+      const button = menu.querySelector("button");
+      if (button) {
+        button.addEventListener("click", (event) =>
+          toggleDropdownMenu(event, menu, dropdownMenus)
+        );
+      }
+
+      // Handle Submenu Dropdowns
+      const dropDownSubmenus = menu.querySelectorAll(
+        ".astronav-dropdown-submenu"
       );
 
-    // Handle Submenu Dropdowns
-    const dropDownSubmenus = menu.querySelectorAll(
-      ".astronav-dropdown-submenu"
-    );
-
-    dropDownSubmenus.forEach((submenu) => {
-      const submenuButton = submenu.querySelector("button");
-      submenuButton &&
-        submenuButton.addEventListener("click", (event) => {
-          event.stopImmediatePropagation();
-          toggleSubmenuDropdown(event, submenu);
-        });
+      dropDownSubmenus.forEach((submenu) => {
+        const submenuButton = submenu.querySelector("button");
+        if (submenuButton) {
+          submenuButton.addEventListener("click", (event) => {
+            event.stopImmediatePropagation();
+            toggleSubmenuDropdown(event, submenu);
+          });
+        }
+      });
     });
-  });
+  }
 
   // Clicking away from dropdown will remove the dropdown class
   document.addEventListener("click", closeAllDropdowns);
 
-  const closeOnClick = menuButton.getAttribute("data-closeOnClick")
-
-  if (closeOnClick) {
-    handleCloseOnClick();
+  function toggleMobileNav(root) {
+    root.querySelectorAll(".astronav-toggle").forEach((el) => {
+      el.classList.toggle("hidden");
+    });
   }
-}
 
-function toggleMobileNav() {
-  [...document.querySelectorAll(".astronav-toggle")].forEach((el) => {
-    el.classList.toggle("hidden");
-  });
-}
+  function toggleDropdownMenu(event, menu, dropdownMenus) {
+    toggleMenu(menu);
 
-function toggleDropdownMenu(event, menu, dropdownMenus) {
-  toggleMenu(menu);
+    // Close one dropdown when selecting another
+    Array.from(dropdownMenus)
+      .filter((el) => el !== menu && !menu.contains(el))
+      .forEach(closeMenu);
 
-  // Close one dropdown when selecting another
-  Array.from(dropdownMenus)
-    .filter((el) => el !== menu && !menu.contains(el))
-    .forEach(closeMenu);
+    event.stopPropagation();
+  }
 
-  event.stopPropagation();
-}
+  function toggleSubmenuDropdown(event, submenu) {
+    event.stopPropagation();
+    toggleMenu(submenu);
 
-function toggleSubmenuDropdown(event, submenu) {
-  event.stopPropagation();
-  toggleMenu(submenu);
+    // Close sibling submenus at the same nesting level
+    const siblingSubmenus = submenu
+      .closest(".astronav-dropdown")
+      .querySelectorAll(".astronav-dropdown-submenu");
 
-  // Close sibling submenus at the same nesting level
-  const siblingSubmenus = submenu
-    .closest(".astronav-dropdown")
-    .querySelectorAll(".astronav-dropdown-submenu");
+    Array.from(siblingSubmenus)
+      .filter((el) => el !== submenu && !submenu.contains(el))
+      .forEach(closeMenu);
+  }
 
-  Array.from(siblingSubmenus)
-    .filter((el) => el !== submenu && !submenu.contains(el))
-    .forEach(closeMenu);
-}
-
-function closeAllDropdowns(event) {
-  const dropdownMenus = document.querySelectorAll(".dropdown-toggle");
-  const dropdownParent = document.querySelectorAll(
-    ".astronav-dropdown, .astronav-dropdown-submenu"
-  );
-  const isButtonInsideDropdown = [
-    ...document.querySelectorAll(
-      `.astronav-dropdown button, .astronav-dropdown label, .astronav-dropdown input,
+  function closeAllDropdowns(event) {
+    const dropdownMenus = document.querySelectorAll(".dropdown-toggle");
+    const dropdownParent = document.querySelectorAll(
+      ".astronav-dropdown, .astronav-dropdown-submenu"
+    );
+    const isButtonInsideDropdown = [
+      ...document.querySelectorAll(
+        `.astronav-dropdown button, .astronav-dropdown label, .astronav-dropdown input,
       .astronav-dropdown-submenu button, .astronav-dropdown-submenu label, .astronav-dropdown-submenu input,
       button[data-astronav]`
-    ),
-  ].some((button) => button.contains(event.target));
+      ),
+    ].some((button) => button.contains(event.target));
 
-  if (!isButtonInsideDropdown) {
-    dropdownMenus.forEach((d) => {
-      // console.log("I ran", d);
-      // if (!d.contains(event.target)) {
-      d.classList.remove("open");
-      d.removeAttribute("open");
-      d.classList.add("hidden");
-      // }
-    });
-    
-    dropdownParent.forEach((d) => {
-      d.classList.remove("open");
-      d.removeAttribute("open");
-      d.setAttribute("aria-expanded", "false");
+    if (!isButtonInsideDropdown) {
+      dropdownMenus.forEach((d) => {
+        d.classList.remove("open");
+        d.removeAttribute("open");
+        d.classList.add("hidden");
+      });
+
+      dropdownParent.forEach((d) => {
+        d.classList.remove("open");
+        d.removeAttribute("open");
+        d.setAttribute("aria-expanded", "false");
+      });
+    }
+  }
+
+  function toggleMenu(menu) {
+    menu.classList.toggle("open");
+    const expanded = menu.getAttribute("aria-expanded") === "true";
+    menu.setAttribute("aria-expanded", expanded ? "false" : "true");
+    menu.hasAttribute("open")
+      ? menu.removeAttribute("open")
+      : menu.setAttribute("open", "");
+
+    const dropdownToggle = menu.querySelector(".dropdown-toggle");
+    const dropdownExpanded = dropdownToggle.getAttribute("aria-expanded");
+    dropdownToggle.classList.toggle("hidden");
+    dropdownToggle.setAttribute(
+      "aria-expanded",
+      dropdownExpanded === "true" ? "false" : "true"
+    );
+  }
+
+  function closeMenu(menu) {
+    menu.classList.remove("open");
+    menu.removeAttribute("open");
+    menu.setAttribute("aria-expanded", "false");
+    const dropdownToggles = menu.querySelectorAll(".dropdown-toggle");
+    dropdownToggles.forEach((toggle) => {
+      toggle.classList.add("hidden");
+      toggle.setAttribute("aria-expanded", "false");
     });
   }
-}
 
-function toggleMenu(menu) {
-  menu.classList.toggle("open");
-  const expanded = menu.getAttribute("aria-expanded") === "true";
-  menu.setAttribute("aria-expanded", expanded ? "false" : "true");
-  menu.hasAttribute("open")
-    ? menu.removeAttribute("open")
-    : menu.setAttribute("open", "");
+  function handleCloseOnClick(root) {
+    const navMenuItems = root.querySelector(".astronav-items");
+    const navLinks = navMenuItems && navMenuItems.querySelectorAll("a");
 
-  const dropdownToggle = menu.querySelector(".dropdown-toggle");
-  const dropdownExpanded = dropdownToggle.getAttribute("aria-expanded");
-  dropdownToggle.classList.toggle("hidden");
-  dropdownToggle.setAttribute(
-    "aria-expanded",
-    dropdownExpanded === "true" ? "false" : "true"
-  );
-}
+    const MenuIcons = root.querySelectorAll(".astronav-toggle");
 
-function closeMenu(menu) {
-  // console.log("closing", menu);
-  menu.classList.remove("open");
-  menu.removeAttribute("open");
-  menu.setAttribute("aria-expanded", "false");
-  const dropdownToggles = menu.querySelectorAll(".dropdown-toggle");
-  dropdownToggles.forEach((toggle) => {
-    toggle.classList.add("hidden");
-    toggle.setAttribute("aria-expanded", "false");
-  });
-}
-
-function handleCloseOnClick() {
-  const navMenuItems = document.querySelector(".astronav-items");
-  const navToggle = document.getElementById("astronav-menu");
-  const navLink = navMenuItems && navMenuItems.querySelectorAll("a");
-
-  const MenuIcons = navToggle.querySelectorAll(".astronav-toggle");
-
-  navLink &&
-    navLink.forEach((item) => {
-      item.addEventListener("click", () => {
-        navMenuItems?.classList.add("hidden");
-        MenuIcons.forEach((el) => {
-          el.classList.toggle("hidden");
+    if (navLinks) {
+      navLinks.forEach((item) => {
+        item.addEventListener("click", () => {
+          navMenuItems?.classList.add("hidden");
+          MenuIcons.forEach((el) => {
+            el.classList.toggle("hidden");
+          });
         });
       });
-    });
-}
+    }
+  }
 </script>
+
+<style>
+  .astronav-toggle-root {
+    display: contents;
+  }
+</style>

--- a/src/Astronav.astro
+++ b/src/Astronav.astro
@@ -1,13 +1,8 @@
 ---
-interface Props {
-  closeOnClick?: boolean;
-}
-const { closeOnClick = false } = Astro.props;
 ---
+<slot/>
 
-<slot />
-
-<script define:vars={{ closeOnClick }}>
+<script>
 ["DOMContentLoaded", "astro:after-swap"].forEach((event) => {
   document.addEventListener(event, addListeners);
 });
@@ -19,26 +14,36 @@ function cloneAndReplace(element) {
 }
 
 function addListeners() {
+  document.querySelectorAll('button[data-astronav]').forEach((button) => {
+    addListenersForButton(`button[data-astronav="${button.getAttribute('data-astronav')}"]`)
+  })
+}
+
+function addListenersForButton(selector: string) {
   // Clean up existing listeners
-  const oldMenuButton = document.getElementById("astronav-menu");
+  const oldMenuButton = document.querySelector(selector);
+
   if (oldMenuButton) {
     cloneAndReplace(oldMenuButton);
   }
 
   const oldDropdownMenus = document.querySelectorAll(".astronav-dropdown");
+
   oldDropdownMenus.forEach((menu) => {
     cloneAndReplace(menu);
   });
 
   // Mobile nav toggle
-  const menuButton = document.getElementById("astronav-menu");
+  const menuButton = document.querySelector(selector);
   menuButton && menuButton.addEventListener("click", toggleMobileNav);
 
   // Dropdown menus
   const dropdownMenus = document.querySelectorAll(".astronav-dropdown");
+  
   dropdownMenus.forEach((menu) => {
     const button = menu.querySelector("button");
-    button &&
+
+    button && 
       button.addEventListener("click", (event) =>
         toggleDropdownMenu(event, menu, dropdownMenus)
       );
@@ -60,6 +65,8 @@ function addListeners() {
 
   // Clicking away from dropdown will remove the dropdown class
   document.addEventListener("click", closeAllDropdowns);
+
+  const closeOnClick = menuButton.getAttribute("data-closeOnClick")
 
   if (closeOnClick) {
     handleCloseOnClick();
@@ -91,6 +98,7 @@ function toggleSubmenuDropdown(event, submenu) {
   const siblingSubmenus = submenu
     .closest(".astronav-dropdown")
     .querySelectorAll(".astronav-dropdown-submenu");
+
   Array.from(siblingSubmenus)
     .filter((el) => el !== submenu && !submenu.contains(el))
     .forEach(closeMenu);
@@ -104,10 +112,11 @@ function closeAllDropdowns(event) {
   const isButtonInsideDropdown = [
     ...document.querySelectorAll(
       `.astronav-dropdown button, .astronav-dropdown label, .astronav-dropdown input,
-	  .astronav-dropdown-submenu button, .astronav-dropdown-submenu label, .astronav-dropdown-submenu input,
-	  #astronav-menu`
+      .astronav-dropdown-submenu button, .astronav-dropdown-submenu label, .astronav-dropdown-submenu input,
+      button[data-astronav]`
     ),
   ].some((button) => button.contains(event.target));
+
   if (!isButtonInsideDropdown) {
     dropdownMenus.forEach((d) => {
       // console.log("I ran", d);
@@ -117,6 +126,7 @@ function closeAllDropdowns(event) {
       d.classList.add("hidden");
       // }
     });
+    
     dropdownParent.forEach((d) => {
       d.classList.remove("open");
       d.removeAttribute("open");

--- a/src/components/MenuIcon.astro
+++ b/src/components/MenuIcon.astro
@@ -1,11 +1,15 @@
 ---
+import { createUniqueId } from "../crypto";
+
 interface Props {
   class?: string;
+  closeOnClick?: boolean;
 }
-const { class: className, ...rest } = Astro.props;
+
+const { class: className, closeOnClick = false, ...rest} = Astro.props;
 ---
 
-<button id="astronav-menu" aria-label="Toggle Menu">
+<button data-astronav={createUniqueId()} data-closeOnClick={closeOnClick} aria-label="Toggle Menu">
   <slot>
     <svg
       fill="currentColor"
@@ -21,12 +25,12 @@ const { class: className, ...rest } = Astro.props;
         fill-rule="evenodd"
         clip-rule="evenodd"
         d="M18.278 16.864a1 1 0 01-1.414 1.414l-4.829-4.828-4.828 4.828a1 1 0 01-1.414-1.414l4.828-4.829-4.828-4.828a1 1 0 011.414-1.414l4.829 4.828 4.828-4.828a1 1 0 111.414 1.414l-4.828 4.829 4.828 4.828z"
-      ></path>
+      />
       <path
         class="astronav-open-icon astronav-toggle"
         fill-rule="evenodd"
         d="M4 5h16a1 1 0 010 2H4a1 1 0 110-2zm0 6h16a1 1 0 010 2H4a1 1 0 010-2zm0 6h16a1 1 0 010 2H4a1 1 0 010-2z"
-      ></path>
+      />
     </svg>
   </slot>
 </button>

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,0 +1,7 @@
+/**
+ * Generates a unique ID for use in component instances.
+ * Uses a random string to ensure uniqueness across builds and renders.
+ */
+export function createUniqueId(): string {
+  return Math.random().toString(36).slice(2, 11);
+}


### PR DESCRIPTION
## Intro
Following this [PR](https://github.com/surjithctly/astro-navbar/pull/34), we wanted to propose an alternative for it.

## Description
Here is the breakdown of why Astronav.astro is structurally necessary:

### 1. The "Desktop Dropdown" Problem
The script currently handles Dropdown toggles as well as the mobile menu.

- Dropdowns are primarily used on Desktop screens.
- MenuIcon (the hamburger button) is typically hidden or not rendered at all on Desktop.
- If we move the logic into MenuIcon , and the user conditionally renders it (e.g., `{isMobile && <MenuIcon />}`), your Dropdowns will stop working on desktop because the script won't be present.

### 2. Scoping & "Islands" (The Fix We Just Made)
We just established that we need a "root" element to isolate multiple navbars on the same page.

- `Astronav.astro` provides this boundary automatically via the `<nav class="astronav-toggle-root">` wrapper.
- If you remove `Astronav.astro`, the user would have to manually add a wrapper div with a specific class to every navbar for the code to work. This degrades the Developer Experience (DX) and makes the library more error-prone to use.

### 3. Separation of Concerns
- MenuIcon should just be a Button (UI).
- Astronav acts as the Controller (Logic).
  It is cleaner to have a dedicated controller component orchestrate the behavior of the children (Menu, Dropdowns, Sticky behaviors) rather than stuffing global navigation logic into a tiny icon component.

### Correction on `closeOnClick`
You are absolutely right that `closeOnClick` belongs on the button. In fact, it is already implemented that way!

- `Astronav.astro` does not accept a `closeOnClick` prop.
- `MenuIcon.astro` does accept it and renders it as a data attribute (`data-closeOnClick`).
- The script in Astronav looks for that attribute on the button to decide whether to enable the behavior.